### PR TITLE
check for null in element access

### DIFF
--- a/src/com/rit/sucy/event/EquipListener.java
+++ b/src/com/rit/sucy/event/EquipListener.java
@@ -139,7 +139,7 @@ public class EquipListener implements Listener
                         plugin.getServer().getPluginManager().callEvent(new PlayerUnequipEvent(player, previous[i]));
                     else if (equips[i] != null && (previous == null || previous[i] == null))
                         plugin.getServer().getPluginManager().callEvent(new PlayerEquipEvent(player, equips[i]));
-                    else if (previous != null && !equips[i].toString().equalsIgnoreCase(previous[i].toString()))
+                    else if (previous != null && previous[i] != null && !equips[i].toString().equalsIgnoreCase(previous[i].toString()))
                     {
                         plugin.getServer().getPluginManager().callEvent(new PlayerUnequipEvent(player, previous[i]));
                         plugin.getServer().getPluginManager().callEvent(new PlayerEquipEvent(player, equips[i]));


### PR DESCRIPTION
Stops errors such as this from happenin:

``` java
java.lang.NullPointerException
        at com.rit.sucy.event.EquipListener$1.run(EquipListener.java:142) ~[?:?]
        at org.bukkit.craftbukkit.v1_9_R1.scheduler.CraftTask.run(CraftTask.java:71) ~[spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at org.bukkit.craftbukkit.v1_9_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:350) [spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at net.minecraft.server.v1_9_R1.MinecraftServer.D(MinecraftServer.java:729) [spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at net.minecraft.server.v1_9_R1.DedicatedServer.D(DedicatedServer.java:400) [spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at net.minecraft.server.v1_9_R1.MinecraftServer.C(MinecraftServer.java:660) [spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:559) [spigot-1.9.jar:git-Spigot-3104eb1-68b7277]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_73]
```
